### PR TITLE
definiendo url de login por defecto

### DIFF
--- a/transmunic/settings.py
+++ b/transmunic/settings.py
@@ -234,6 +234,9 @@ COLORS_ARRAY = [
     '#96bfff',
 ]
 
+'' # Definiendo url login
+LOGIN_URL = '/admin/login/'
+
 try:
     LOCAL_SETTINGS
 except NameError:


### PR DESCRIPTION
defino LOGIN_URL con /admin/login, debido a que el sistema aun estaba tomando por defecto a url /account/login => dicha url ya no existe en el sistema